### PR TITLE
Create `FLOGS()` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A lightweight, no-frills logging library for Arduino & friends.
 
-* simple interface - just three macros
+* simple interface - just four macros
 * printf-like formatting
 * each log entry is prepended by timestamp and amount of available free RAM
 * automatically uses flash memory to save SRAM (if supported)
@@ -30,9 +30,12 @@ void setup() {
     // use LOGS() for simple logging of single arguments
     const char *pStr = "some string from RAM";
     LOGS(pStr);
-    LOGS(F("this string is stored in flash memory"));
     LOGS(String("some String object"));
     LOGS(123);
+    
+    // these examples are equivalent
+    LOGS(F("this string is stored in flash memory"));
+    FLOGS("this string is also stored in flash memory"));
 }
 
 void loop() { }
@@ -88,7 +91,7 @@ header.  If `ENABLE_LOG4ARDUINO` is not defined, then logging will be disabled
 
 ### Logging interface
 
-3 Macros are used for logging: `LOG_INIT`, `LOG` and `LOGS`:
+4 Macros are used for logging: `LOG_INIT`, `LOG`; `LOGS` and `FLOGS`:
 
 #### LOG_INIT
 
@@ -109,6 +112,11 @@ Use the `LOG(fmt, ...)` macro to log in a
 
 Use the `LOGS(s)` (the *S* stands for *simple*) macro, to directly log out the
 given value using the log target's `print` method.
+
+#### FLOGS(s)
+
+Use the `FLOGS(s)` (the added *F* stands for *flash*) macro, to log out the
+given value (now stored in Flash memory) using the log target's `print` method.
 
 ## A word on log levels
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ void setup() {
     
     // these examples are equivalent
     LOGS(F("this string is stored in flash memory"));
-    FLOGS("this string is also stored in flash memory"));
+    FLOGS("this string is also stored in flash memory");
 }
 
 void loop() { }

--- a/src/log4arduino.h
+++ b/src/log4arduino.h
@@ -20,12 +20,14 @@ extern void log4arduino_debug_printf(const __FlashStringHelper* fmt, ...);
         _log4arduino_target->println(s); \
     }
 #define LOG(fmt, ...) log4arduino_debug_printf(F(fmt), ##__VA_ARGS__)
+#define FLOGS(s) LOGS(F(s))
 
 #else
 
 #define LOG_INIT(p)
 #define LOG(...)
 #define LOGS(s)
+#define FLOGS(s)
 
 #endif
 


### PR DESCRIPTION
Hi!

I created this macro because `LOGS()` was still storing my strings in SRAM. I originally added it in my own `GlobalFunctions.h` file (and it works) but not in `log4arduino.h` itself, so I didn't really test the code there

Goodbye!